### PR TITLE
Simplify 'npm start' for the webpack build

### DIFF
--- a/webpack/README.md
+++ b/webpack/README.md
@@ -22,7 +22,7 @@ $ npm install
 And finally we'll want to start up a webpack development server:
 
 ```
-$ npm run start
+$ npm start
 ```
 
 After this you can visit http://localhost:8080 and you should see an interactive


### PR DESCRIPTION
the 'run' keyword is optional for the web pack server