### PR TITLE
Update requirements for running JS examples

### DIFF
--- a/markdown/Cargo.toml
+++ b/markdown/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ['cdylib']
 
 [dependencies]
 pulldown-cmark = { version = "0.5.3", default-features = false }
-wasm-bindgen = "0.2.49"
+wasm-bindgen = "0.2.55"

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -17,12 +17,15 @@ Next you'll want to install necessary dependencies:
 $ npm install
 ```
 
-Next you'll need to be sure to execute `node` with experimental flags. It's
-recommended to use Node.js 12+ here as well
+Next you'll need to be sure to execute `node` with experimental flags. It
+requires Node.js 13+ here as well
 
 ```
-$ node --experimental-modules --loader ./loader.mjs ./run.mjs
+$ node --experimental-wasm-mv --experimental-modules --loader ./loader.mjs ./run.mjs
 ```
+
+Note that Node.js 13 with the `--experimental-wasm-mv` flag is required to
+enable the multi-value support needed by the polyfill.
 
 ## How does it work?
 

--- a/webpack/README.md
+++ b/webpack/README.md
@@ -28,6 +28,10 @@ $ npm start
 After this you can visit http://localhost:8080 and you should see an interactive
 markdown renderer!
 
+> **Note**: At the time of this writing only Chrome has support for multi-value,
+> and it has to be enabled by activating the "Experimental WebAssembly" setting
+> under `chrome://flags`
+
 ## How does it work?
 
 Support for this example is provided through a Webpack loader called


### PR DESCRIPTION
* Update dependencies for `wasm-bindgen`
* Note that multi-value needs enabling