### PR TITLE
Update Wasmtime package reference for fix.

### DIFF
--- a/dotnet/WasmtimeDemo.csproj
+++ b/dotnet/WasmtimeDemo.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="wasmtime" Version="0.8.0-preview1" />
+    <PackageReference Include="wasmtime" Version="0.8.0-preview2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This commit updates the .NET demo to use a fixed version of the API so that it
runs properly on Windows.